### PR TITLE
fix: field name routing_did in keylist response body

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -9,7 +9,7 @@ inThisBuild(
 
 /** Versions */
 lazy val V = new {
-  val scalaDID = "0.1.0-M2"
+  val scalaDID = "0.1.0-M3"
 //   val scalajsJavaSecureRandom = "1.0.0"
 
   // FIXME another bug in the test framework https://github.com/scalameta/munit/issues/554


### PR DESCRIPTION
fix: Field name routing_did in keylist response body

Fix: Mediator returns "routing_did" instead of "recipient_did" in keylist response body
Fix for ATL-4845