### PR TITLE
feat: Not send response errors to the caller

### DIFF
--- a/mediator/src/main/scala/io/iohk/atala/mediator/Error.scala
+++ b/mediator/src/main/scala/io/iohk/atala/mediator/Error.scala
@@ -14,7 +14,7 @@ object MediatorDidError {
   def apply(error: DidFail) = new MediatorDidError(error)
 }
 
-final case class MediatorThrowable(val error: String) extends StorageError
+final case class MediatorThrowable(val error: String) extends MediatorError
 object MediatorThrowable {
   def apply(throwable: Throwable) = new MediatorThrowable(throwable.getClass.getName() + ":" + throwable.getMessage)
 }
@@ -47,4 +47,4 @@ object ProtocolError {
 }
 
 case class MissingProtocolError(piuri: PIURI) extends ProtocolError
-case class FailToEncodeMessage(piuri: PIURI, error: String) extends ProtocolError
+// case class FailToEncodeMessage(piuri: PIURI, error: String) extends ProtocolError

--- a/mediator/src/main/scala/io/iohk/atala/mediator/app/MediatorAgent.scala
+++ b/mediator/src/main/scala/io/iohk/atala/mediator/app/MediatorAgent.scala
@@ -241,14 +241,30 @@ object MediatorAgent {
         for {
           agent <- ZIO.service[MediatorAgent]
           data <- req.body.asString
-          maybeSyncReplyMsg <- agent
+          ret <- agent
             .receiveMessage(data, None)
-            .mapError(fail => MediatorException(fail))
-          ret = maybeSyncReplyMsg match
-            case None        => Response.ok
-            case Some(value) => Response.json(value.toJson)
+            .map {
+              case None        => Response.ok
+              case Some(value) => Response.json(value.toJson)
+            }
+            .catchAll {
+              case MediatorDidError(error) =>
+                ZIO.logError(s"Error MediatorDidError: $error") *>
+                  ZIO.succeed(Response.status(Status.BadRequest))
+              case MediatorThrowable(error) =>
+                ZIO.logError(s"Error MediatorThrowable: $error") *>
+                  ZIO.succeed(Response.status(Status.BadRequest))
+              case StorageCollection(error) =>
+                ZIO.logError(s"Error StorageCollection: $error") *>
+                  ZIO.succeed(Response.status(Status.BadRequest))
+              case StorageThrowable(error) =>
+                ZIO.logError(s"Error StorageThrowable: $error") *>
+                  ZIO.succeed(Response.status(Status.BadRequest))
+              case MissingProtocolError(piuri) =>
+                ZIO.logError(s"MissingProtocolError ('$piuri')") *>
+                  ZIO.succeed(Response.status(Status.BadRequest)) // TODO
+            }
         } yield ret
-
       // TODO [return_route extension](https://github.com/decentralized-identity/didcomm-messaging/blob/main/extensions/return_route/main.md)
       case req @ Method.POST -> !! =>
         ZIO


### PR DESCRIPTION
feat: Not send response errors to the caller

Meditor should not send http response on errors to the caller
For ATL-5200