### PR TITLE
feat: reply asynchronous unless return_route all

### DIFF
--- a/mediator/src/main/scala/io/iohk/atala/mediator/actions/ActionUtils.scala
+++ b/mediator/src/main/scala/io/iohk/atala/mediator/actions/ActionUtils.scala
@@ -87,7 +87,7 @@ object ActionUtils {
                         case Some(replyTo) => send2DIDs.contains(replyTo)
                       }
                     }
-                  } || action.isInstanceOf[SyncReplyOnly]
+                  } // || action.isInstanceOf[SyncReplyOnly]
                 )
         } yield maybeSyncReplyMsg
     }


### PR DESCRIPTION
All DIDComm call must be asynchronous unless it has return_route header specified For ATL-5535