### PR TITLE
fix: alias list is empty in new acounts by default

### DIFF
--- a/mediator/src/main/scala/io/iohk/atala/mediator/db/UserAccountRepo.scala
+++ b/mediator/src/main/scala/io/iohk/atala/mediator/db/UserAccountRepo.scala
@@ -60,7 +60,7 @@ class UserAccountRepo(reactiveMongoApi: ReactiveMongoApi)(using ec: ExecutionCon
         case None =>
           val value = DidAccount(
             did = did,
-            alias = Seq(did),
+            alias = Seq.empty,
             messagesRef = Seq.empty
           )
           ZIO

--- a/mediator/src/test/scala/io/iohk/atala/mediator/db/UserAccountRepoSpec.scala
+++ b/mediator/src/test/scala/io/iohk/atala/mediator/db/UserAccountRepoSpec.scala
@@ -62,14 +62,14 @@ object UserAccountRepoSpec extends ZIOSpecDefault with AccountStubSetup {
     test("Add alias to existing Did Account return right nModified value 1") {
       for {
         userAccount <- ZIO.service[UserAccountRepo]
-        result <- userAccount.addAlias(DIDSubject(alice), DIDSubject(bob))
+        result <- userAccount.addAlias(owner = DIDSubject(alice), newAlias = DIDSubject(bob))
         didAccount <- userAccount.getDidAccount(DIDSubject(alice))
       } yield {
         val alias: Seq[String] = didAccount.map(_.alias.map(_.did)).getOrElse(Seq.empty)
         assertTrue(result.isRight) &&
         assertTrue(result == Right((1))) &&
         assertTrue(didAccount.isDefined) &&
-        assertTrue(alias == Seq(alice, bob))
+        assertTrue(alias == Seq(bob))
       }
     },
     test("insert/create a UserAccount for a DID that is used as a alias should fail") {
@@ -80,17 +80,30 @@ object UserAccountRepoSpec extends ZIOSpecDefault with AccountStubSetup {
         assertTrue(result.isLeft)
       }
     },
+    test("Add owner as alias to existing Did Account return right with nModified value 1") {
+      for {
+        userAccount <- ZIO.service[UserAccountRepo]
+        result <- userAccount.addAlias(owner = DIDSubject(alice), newAlias = DIDSubject(alice))
+        didAccount <- userAccount.getDidAccount(DIDSubject(alice))
+      } yield {
+        val alias: Seq[String] = didAccount.map(_.alias.map(_.did)).getOrElse(Seq.empty)
+        assertTrue(result.isRight) &&
+        assertTrue(result == Right(1)) &&
+        assertTrue(didAccount.isDefined) &&
+        assertTrue(alias.sorted == Seq(alice, bob).sorted)
+      }
+    },
     test("Add same alias to existing Did Account return right with nModified value 0") {
       for {
         userAccount <- ZIO.service[UserAccountRepo]
-        result <- userAccount.addAlias(DIDSubject(alice), DIDSubject(alice))
+        result <- userAccount.addAlias(owner = DIDSubject(alice), newAlias = DIDSubject(alice))
         didAccount <- userAccount.getDidAccount(DIDSubject(alice))
       } yield {
         val alias: Seq[String] = didAccount.map(_.alias.map(_.did)).getOrElse(Seq.empty)
         assertTrue(result.isRight) &&
         assertTrue(result == Right(0)) &&
         assertTrue(didAccount.isDefined) &&
-        assertTrue(alias == Seq(alice, bob))
+        assertTrue(alias.sorted == Seq(alice, bob).sorted)
       }
     },
     test("Remove alias to existing Did Account should return right with nModified value 1 ") {


### PR DESCRIPTION
The alias list is empty by default when mediate is grant. After receiving a 'mediate-grant' message the 'recipient' should update his 'recipient_did' with a 'recipient-update' message and add DIDs. In order for the 'mediator' to start accepting Forward Message for those DIDs.