### PR TITLE
fix: set default endpoint to localhost

### DIFF
--- a/mediator/src/main/resources/application.conf
+++ b/mediator/src/main/resources/application.conf
@@ -16,7 +16,7 @@ mediator = {
       x = "MBjnXZxkMcoQVVL21hahWAw43RuAG-i64ipbeKKqwoA"
       x = ${?KEY_AUTHENTICATION_X}
     }
-    endpoint = "https://mediator-test-env.atalaprism.io/mediator"
+    endpoint = "http://localhost:8080"
     endpoint = ${?SERVICE_ENDPOINT}
   }
   server.http.port = 8080


### PR DESCRIPTION
I think having the default us localhost is more useful.
For example, if I want to run tests I don't need to change that.

Otherwise, I wouldn't setup at all and make the application crash if `SERVICE_ENDPOINT` is not configured