### PR TITLE
fix(infra): add sync-wave to certificate template

### DIFF
--- a/infrastructure/charts/mediator/templates/certificate.yaml
+++ b/infrastructure/charts/mediator/templates/certificate.yaml
@@ -6,6 +6,8 @@ metadata:
   namespace: "{{ .Release.Namespace }}"
   labels:
     {{ template "labels.common" . }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
 spec:
   secretName: "prism-mediator-base-path-secret"
   duration: 2160h0m0s # 90d


### PR DESCRIPTION
Updated certificate template to include `sync-wave` option, so it's always created before other services depending on it such as `apisixtls`. 

Same setup is in the [agent template](https://github.com/hyperledger-labs/open-enterprise-agent/blob/77b358893fda99eb4b4d4fdb9d39f347e3f5bab5/infrastructure/charts/agent/templates/certificate.yaml#L9-L10) too.