### PR TITLE
feat: Support protocol discover-features 2.0

### DIFF
--- a/mediator/src/main/scala/io/iohk/atala/mediator/protocols/DiscoverFeaturesExecuter.scala
+++ b/mediator/src/main/scala/io/iohk/atala/mediator/protocols/DiscoverFeaturesExecuter.scala
@@ -1,0 +1,80 @@
+package io.iohk.atala.mediator.protocols
+
+import fmgp.crypto.error.FailToParse
+import fmgp.did.Agent
+import fmgp.did.comm.{PIURI, PlaintextMessage}
+import fmgp.did.comm.protocol.discoverfeatures2._
+import io.iohk.atala.mediator.{MediatorDidError, MediatorError}
+import io.iohk.atala.mediator.actions.{Action, NoReply, ProtocolExecuter, ProtocolExecuterWithServices, Reply}
+import zio.ZIO
+
+class DiscoverFeaturesExecuter extends ProtocolExecuterWithServices[ProtocolExecuter.Services, MediatorError] {
+
+  override def supportedPIURI: Seq[PIURI] = Seq(FeatureQuery.piuri, FeatureDisclose.piuri)
+
+  override def program[R1 <: Agent](
+      plaintextMessage: PlaintextMessage
+  ): ZIO[R1, MediatorError, Action] = {
+    // the val is from the match to be definitely stable
+    val piuriFeatureQuery = FeatureQuery.piuri
+    val piuriFeatureDisclose = FeatureDisclose.piuri
+
+    plaintextMessage.`type` match
+      case `piuriFeatureQuery` =>
+        for {
+          ret <- plaintextMessage.toFeatureQuery match
+            case Left(error) =>
+              ZIO.logError(s"Fail in FeatureQuery: $error") *>
+                ZIO.fail(MediatorDidError(FailToParse(error)))
+            case Right(featureQuery) =>
+              for {
+                _ <- ZIO.logInfo(featureQuery.toString())
+                agent <- ZIO.service[Agent]
+                allProtocols = Seq(
+                  FeatureDisclose.Disclose(
+                    `feature-type` = "protocol",
+                    id = "https://didcomm.org/routing/2.0",
+                    roles = Some(Seq("mediator")), // sender
+                  ),
+                  FeatureDisclose.Disclose(
+                    `feature-type` = "protocol",
+                    id = "https://didcomm.org/coordinate-mediation/2.0",
+                    roles = Some(Seq("responder")), // requester
+                  ),
+                  FeatureDisclose.Disclose(
+                    `feature-type` = "protocol",
+                    id = "https://didcomm.org/messagepickup/3.0",
+                    roles = Some(Seq("mediator")), // recipient
+                  ),
+                  FeatureDisclose.Disclose(
+                    `feature-type` = "protocol",
+                    id = "https://didcomm.org/trust-ping/2.0",
+                    roles = Some(Seq("receiver")), // sender
+                  ),
+                  FeatureDisclose.Disclose(
+                    `feature-type` = "protocol",
+                    id = "https://didcomm.org/discover-features/2.0",
+                    roles = Some(Seq("responder")), // requester
+                  ),
+                )
+                filter = featureQuery.queries
+                  .filter(q => q.`feature-type` == "protocol")
+                  .map(q => scala.util.matching.Regex(q.`match`))
+                discloses = filter.flatMap(reg => allProtocols.filter(e => reg.matches(e.id))).toSet
+              } yield FeatureDisclose(
+                thid = Some(featureQuery.id),
+                to = Set(featureQuery.from.asTO),
+                from = agent.id,
+                disclosures = discloses.toSeq,
+              )
+        } yield Reply(ret.toPlaintextMessage)
+
+      case `piuriFeatureDisclose` =>
+        for {
+          _ <- plaintextMessage.toFeatureDisclose match
+            case Left(error)            => ZIO.fail(MediatorDidError(FailToParse(error)))
+            case Right(featureDisclose) => ZIO.logInfo(featureDisclose.toString())
+        } yield NoReply
+  }
+
+}

--- a/mediator/src/main/scala/io/iohk/atala/mediator/protocols/DiscoverFeaturesExecuter.scala
+++ b/mediator/src/main/scala/io/iohk/atala/mediator/protocols/DiscoverFeaturesExecuter.scala
@@ -8,7 +8,7 @@ import io.iohk.atala.mediator.{MediatorDidError, MediatorError}
 import io.iohk.atala.mediator.actions.{Action, NoReply, ProtocolExecuter, ProtocolExecuterWithServices, Reply}
 import zio.ZIO
 
-class DiscoverFeaturesExecuter extends ProtocolExecuterWithServices[ProtocolExecuter.Services, MediatorError] {
+object DiscoverFeaturesExecuter extends ProtocolExecuterWithServices[ProtocolExecuter.Services, MediatorError] {
 
   override def supportedPIURI: Seq[PIURI] = Seq(FeatureQuery.piuri, FeatureDisclose.piuri)
 

--- a/mediator/src/test/scala/io/iohk/atala/mediator/db/AgentStub.scala
+++ b/mediator/src/test/scala/io/iohk/atala/mediator/db/AgentStub.scala
@@ -45,6 +45,7 @@ object AgentStub {
 
   def bobAgentLayer: ULayer[Agent] = ZLayer.succeed(bobAgent)
 
+  /** Mediator */
   val agentLayer = mediatorConfig.agentLayer
 
 }

--- a/mediator/src/test/scala/io/iohk/atala/mediator/db/DidAccountStubSetup.scala
+++ b/mediator/src/test/scala/io/iohk/atala/mediator/db/DidAccountStubSetup.scala
@@ -1,37 +1,44 @@
 package io.iohk.atala.mediator.db
+import fmgp.did.DIDSubject
 import fmgp.did.comm.{EncryptedMessage, PlaintextMessage}
 import fmgp.did.method.peer.{DIDPeer2, DIDPeerServiceEncoded}
 //import io.iohk.atala.mediator.db.AgentStub.{keyAgreement, keyAuthentication}
 import zio.json.*
 trait DidAccountStubSetup {
   val alice =
-    "did:peer:2.Ez6LSghwSE437wnDE1pt3X6hVDUQzSjsHzinpX3XFvMjRAm7y.Vz6Mkhh1e5CEYYq6JBUcTZ6Cp2ranCWRrv7Yax3Le4N59R6dd.SeyJ0IjoiZG0iLCJzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwIiwiciI6W10sImEiOlsiZGlkY29tbS92MiJdfQ"
+    DIDSubject(
+      "did:peer:2.Ez6LSghwSE437wnDE1pt3X6hVDUQzSjsHzinpX3XFvMjRAm7y.Vz6Mkhh1e5CEYYq6JBUcTZ6Cp2ranCWRrv7Yax3Le4N59R6dd.SeyJ0IjoiZG0iLCJzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwIiwiciI6W10sImEiOlsiZGlkY29tbS92MiJdfQ"
+    )
   val bob =
-    "did:peer:2.Ez6LSkGy3e2z54uP4U9HyXJXRpaF2ytsnTuVgh6SNNmCyGZQZ.Vz6Mkjdwvf9hWc6ibZndW9B97si92DSk9hWAhGYBgP9kUFk8Z.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9ib2IuZGlkLmZtZ3AuYXBwLyIsInIiOltdLCJhIjpbImRpZGNvbW0vdjIiXX0"
+    DIDSubject(
+      "did:peer:2.Ez6LSkGy3e2z54uP4U9HyXJXRpaF2ytsnTuVgh6SNNmCyGZQZ.Vz6Mkjdwvf9hWc6ibZndW9B97si92DSk9hWAhGYBgP9kUFk8Z.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9ib2IuZGlkLmZtZ3AuYXBwLyIsInIiOltdLCJhIjpbImRpZGNvbW0vdjIiXX0"
+    )
 
-  val encryptedMessageAlice: Either[String, EncryptedMessage] = """{
-                                                             |	"ciphertext": "L8wzawffzL7kbVyDcMiHgQMwlqLUqWDYOwH4f0VOFK7sJL8vO-H_JBDCADu7gvH1MDHdVJDXQmSv5dDXp6JYubagcSfBqyZGKGOQDQz-1Ir6-sqZ9K5xRPMt76dYbSswrxhaROVJvtAXyrTmN3KEv8SgP_vt8za5QU6B8cM6gp2CycJKoIhETnhVEVjHnrX0YcyzBsLhd-ZKb8e1Nlz_XSh-3cw1oIQMFjXHnU3PSjrqXcrC-4qSGpVVpHvMSOF3o2EbLGEpP-8UbI0psgSLd9a2VUF9xV55r7Bvn_zJp6tC3-KZKNLO0Rc2K-6JRgyyZjo7O_8aj7Ns6Lx0OjUXoKLiA6B79goHiv8qxJ04k5EWD_h8gt4M3_oByH_cVXH35RDK5SwNV6cVl6zRqiHUR9Ilivh6kfOLGqM2sXCKpXE78qRgHOBeOtl08JHFQO5oFkt1ob8iDqczX0nu-qwlckiibnPK1VvhFnmgLyc9lIUsi_xlCNKqIBZCKoi03xrjNobcM1dWFG7yE04nT-sSiakRNwVHBmNCyA5JhEFQ92d1xpXFGM1ojtiHCPkN5nqe7lMYVM2r7QFnN1xTHwaDWddKprW3vkz_RP7tpoPlWk6X8rLoYUvYc3MqNdbj91QMlho5rU472EX3gprIDeNV7VQiKWoAksFe1hdt62zLH8mJJjUZ3lyq4YjOmrqg7g6RArUWC6KbPgmnuJCqwigpjlwRUCBTPISzaZETAisyluIyuMW8QlRCSQdWnfPZAU2fpLBcviMODMzZTULECvRBef05Fvtd_xRCCbpKpDkGxAY",
-                                                             |	"protected": "eyJlcGsiOnsia3R5IjoiT0tQIiwiY3J2IjoiWDI1NTE5IiwieCI6Ikp2TXhvYXZJaUxaUWVrNDA2eXNtWThQOGpkZGFHSjVIaVNRR0ltWHZWQ2MifSwiYXB2IjoiLWNOQ3l0eFVrSHpSRE5SckV2Vm05S0VmZzhZcUtQVnVVcVg1a0VLbU9yMCIsInNraWQiOiJkaWQ6cGVlcjoyLkV6NkxTa0d5M2UyejU0dVA0VTlIeVhKWFJwYUYyeXRzblR1VmdoNlNOTm1DeUdaUVouVno2TWtqZHd2ZjloV2M2aWJabmRXOUI5N3NpOTJEU2s5aFdBaEdZQmdQOWtVRms4Wi5TZXlKMElqb2laRzBpTENKeklqb2lhSFIwY0hNNkx5OWliMkl1Wkdsa0xtWnRaM0F1WVhCd0x5SXNJbklpT2x0ZExDSmhJanBiSW1ScFpHTnZiVzB2ZGpJaVhYMCM2TFNrR3kzZTJ6NTR1UDRVOUh5WEpYUnBhRjJ5dHNuVHVWZ2g2U05ObUN5R1pRWiIsImFwdSI6IlpHbGtPbkJsWlhJNk1pNUZlalpNVTJ0SGVUTmxNbm8xTkhWUU5GVTVTSGxZU2xoU2NHRkdNbmwwYzI1VWRWWm5hRFpUVGs1dFEzbEhXbEZhTGxaNk5rMXJhbVIzZG1ZNWFGZGpObWxpV201a1Z6bENPVGR6YVRreVJGTnJPV2hYUVdoSFdVSm5VRGxyVlVack9Gb3VVMlY1U2pCSmFtOXBXa2N3YVV4RFNucEphbTlwWVVoU01HTklUVFpNZVRscFlqSkpkVnBIYkd0TWJWcDBXak5CZFZsWVFuZE1lVWx6U1c1SmFVOXNkR1JNUTBwb1NXcHdZa2x0VW5CYVIwNTJZbGN3ZG1ScVNXbFlXREFqTmt4VGEwZDVNMlV5ZWpVMGRWQTBWVGxJZVZoS1dGSndZVVl5ZVhSemJsUjFWbWRvTmxOT1RtMURlVWRhVVZvIiwidHlwIjoiYXBwbGljYXRpb24vZGlkY29tbS1lbmNyeXB0ZWQranNvbiIsImVuYyI6IkEyNTZDQkMtSFM1MTIiLCJhbGciOiJFQ0RILTFQVStBMjU2S1cifQ",
-                                                             |	"recipients": [{
-                                                             |		"encrypted_key": "eFHcJkoUle7ZkksvZjvhJHLagF7y5B5gDQX11tc1kus2xa3Vn_QmzyVwFzScOHTCEjWRUe7r63rHBFBw0El2ukZW2tcitxr8",
-                                                             |		"header": {
-                                                             |			"kid": "did:peer:2.Ez6LSghwSE437wnDE1pt3X6hVDUQzSjsHzinpX3XFvMjRAm7y.Vz6Mkhh1e5CEYYq6JBUcTZ6Cp2ranCWRrv7Yax3Le4N59R6dd.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9hbGljZS5kaWQuZm1ncC5hcHAvIiwiciI6W10sImEiOlsiZGlkY29tbS92MiJdfQ#6LSghwSE437wnDE1pt3X6hVDUQzSjsHzinpX3XFvMjRAm7y"
-                                                             |		}
-                                                             |	}],
-                                                             |	"tag": "6MUE-lIZFVRId9qX-0If18EsPcfld_a3r2gQXXq4ms4",
-                                                             |	"iv": "plEK7sqstAIkIxVKyfuuYg"
-                                                             |}""".stripMargin.fromJson[EncryptedMessage]
-  val encryptedMessageBob: Either[String, EncryptedMessage] = """{
-                                                                |	"ciphertext": "-dyjeU0aRQ8F87yAJFbOmmuon0UtEhQpmDQhYclMiTAqi06wH2bLTjtJNIOFG9sJ12uIyaQahPzCFBUyR2X22Oyl-1-Un0LOCAoRP584JuN19NdgKIytmSm4pg4VeSJ56SKO5D3Qe3G8XQa_7vO8O9-b_6V9mQXXZDkknNbphuiD7S53ss_VJzbgQVLRxkBrbnU1PL7yC6AhkAZNkUNCS8GGYbdEKFeRsdWjoROEnuQ1zzPN28eO3T4Wmt2APQ10vHum3Bl1RTiPRGCx3C-fSi05F-521jyP0rwyLeMZdBLruDz2IrUudtimFI3CKQ8_BcmuXTlLa1vw2hKlhk1_ppAmggW-qrjyZPiC9-XIN02OxZox5Xzba-cmg05Dj2zmEXryrxqFfyJlrV5FKSvWDfqeNAA9QNE0aUsgpKK9gOmu5pJRCuYNL96lbxdSCR4BiuX1G_ma2gagdIIY-70d22UPGcrZTw7Blet574i5U_bIDpZw4Az0UxoKNDbCDPOpn-Shojo5n_5FFbaPky0H0N99-9cx-Ns-3NMQecpupPQ9QJ-A2KWBTLYrJofLCBWv_ysqJ3Cde9fQ3xi5DTB13dhbxKVCgzdHKlwnqPC0C3mjFs_eZ1jnzBiUAKLvD_aWMwqx7y8GUhSfXlX3hImqtXaKBu2Koc1esUOvQwadHUj5pSmsNKJJcQLzsOcuYz8U9peRevrft3sy7fm9Ne2L3SSsoCFJP1N8U8bRLmyhY0CDuCNlvXxy_VFoSdPms40d1BNZObhgwO9Ca8kp1r0ITl22repvpMQYcQ83m9fkTXg",
-                                                                |	"protected": "eyJlcGsiOnsia3R5IjoiT0tQIiwiY3J2IjoiWDI1NTE5IiwieCI6ImNKRzZVeVJRbnhOM2RCa3ZQcndmZXZabFBwRzA0SzFyTzZHTjdnQkNyVFUifSwiYXB2IjoiLWNOQ3l0eFVrSHpSRE5SckV2Vm05S0VmZzhZcUtQVnVVcVg1a0VLbU9yMCIsInNraWQiOiJkaWQ6cGVlcjoyLkV6NkxTa0d5M2UyejU0dVA0VTlIeVhKWFJwYUYyeXRzblR1VmdoNlNOTm1DeUdaUVouVno2TWtqZHd2ZjloV2M2aWJabmRXOUI5N3NpOTJEU2s5aFdBaEdZQmdQOWtVRms4Wi5TZXlKMElqb2laRzBpTENKeklqb2lhSFIwY0hNNkx5OWliMkl1Wkdsa0xtWnRaM0F1WVhCd0x5SXNJbklpT2x0ZExDSmhJanBiSW1ScFpHTnZiVzB2ZGpJaVhYMCM2TFNrR3kzZTJ6NTR1UDRVOUh5WEpYUnBhRjJ5dHNuVHVWZ2g2U05ObUN5R1pRWiIsImFwdSI6IlpHbGtPbkJsWlhJNk1pNUZlalpNVTJ0SGVUTmxNbm8xTkhWUU5GVTVTSGxZU2xoU2NHRkdNbmwwYzI1VWRWWm5hRFpUVGs1dFEzbEhXbEZhTGxaNk5rMXJhbVIzZG1ZNWFGZGpObWxpV201a1Z6bENPVGR6YVRreVJGTnJPV2hYUVdoSFdVSm5VRGxyVlVack9Gb3VVMlY1U2pCSmFtOXBXa2N3YVV4RFNucEphbTlwWVVoU01HTklUVFpNZVRscFlqSkpkVnBIYkd0TWJWcDBXak5CZFZsWVFuZE1lVWx6U1c1SmFVOXNkR1JNUTBwb1NXcHdZa2x0VW5CYVIwNTJZbGN3ZG1ScVNXbFlXREFqTmt4VGEwZDVNMlV5ZWpVMGRWQTBWVGxJZVZoS1dGSndZVVl5ZVhSemJsUjFWbWRvTmxOT1RtMURlVWRhVVZvIiwidHlwIjoiYXBwbGljYXRpb24vZGlkY29tbS1lbmNyeXB0ZWQranNvbiIsImVuYyI6IkEyNTZDQkMtSFM1MTIiLCJhbGciOiJFQ0RILTFQVStBMjU2S1cifQ",
-                                                                |	"recipients": [{
-                                                                |		"encrypted_key": "KCjv83os8FnpVaIUgcuYV-5TIw4VYuGIoHozQ0JVlIwK2sEkxwWg10yh0UlbbcnNVfF_OBr4OkJUczj7pB0spRhvjoDHBM_s",
-                                                                |		"header": {
-                                                                |			"kid": "did:peer:2.Ez6LSghwSE437wnDE1pt3X6hVDUQzSjsHzinpX3XFvMjRAm7y.Vz6Mkhh1e5CEYYq6JBUcTZ6Cp2ranCWRrv7Yax3Le4N59R6dd.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9hbGljZS5kaWQuZm1ncC5hcHAvIiwiciI6W10sImEiOlsiZGlkY29tbS92MiJdfQ#6LSghwSE437wnDE1pt3X6hVDUQzSjsHzinpX3XFvMjRAm7y"
-                                                                |		}
-                                                                |	}],
-                                                                |	"tag": "iR0meUd8R3X5dleMywNHq5NaGJ4g0h2tok414SJ7UGI",
-                                                                |	"iv": "T-I0b4fIktFXVhAIFoSmQg"
-                                                                |}""".stripMargin.fromJson[EncryptedMessage]
+  val encryptedMessageAlice: Either[String, EncryptedMessage] =
+    """{
+      |	"ciphertext": "L8wzawffzL7kbVyDcMiHgQMwlqLUqWDYOwH4f0VOFK7sJL8vO-H_JBDCADu7gvH1MDHdVJDXQmSv5dDXp6JYubagcSfBqyZGKGOQDQz-1Ir6-sqZ9K5xRPMt76dYbSswrxhaROVJvtAXyrTmN3KEv8SgP_vt8za5QU6B8cM6gp2CycJKoIhETnhVEVjHnrX0YcyzBsLhd-ZKb8e1Nlz_XSh-3cw1oIQMFjXHnU3PSjrqXcrC-4qSGpVVpHvMSOF3o2EbLGEpP-8UbI0psgSLd9a2VUF9xV55r7Bvn_zJp6tC3-KZKNLO0Rc2K-6JRgyyZjo7O_8aj7Ns6Lx0OjUXoKLiA6B79goHiv8qxJ04k5EWD_h8gt4M3_oByH_cVXH35RDK5SwNV6cVl6zRqiHUR9Ilivh6kfOLGqM2sXCKpXE78qRgHOBeOtl08JHFQO5oFkt1ob8iDqczX0nu-qwlckiibnPK1VvhFnmgLyc9lIUsi_xlCNKqIBZCKoi03xrjNobcM1dWFG7yE04nT-sSiakRNwVHBmNCyA5JhEFQ92d1xpXFGM1ojtiHCPkN5nqe7lMYVM2r7QFnN1xTHwaDWddKprW3vkz_RP7tpoPlWk6X8rLoYUvYc3MqNdbj91QMlho5rU472EX3gprIDeNV7VQiKWoAksFe1hdt62zLH8mJJjUZ3lyq4YjOmrqg7g6RArUWC6KbPgmnuJCqwigpjlwRUCBTPISzaZETAisyluIyuMW8QlRCSQdWnfPZAU2fpLBcviMODMzZTULECvRBef05Fvtd_xRCCbpKpDkGxAY",
+      |	"protected": "eyJlcGsiOnsia3R5IjoiT0tQIiwiY3J2IjoiWDI1NTE5IiwieCI6Ikp2TXhvYXZJaUxaUWVrNDA2eXNtWThQOGpkZGFHSjVIaVNRR0ltWHZWQ2MifSwiYXB2IjoiLWNOQ3l0eFVrSHpSRE5SckV2Vm05S0VmZzhZcUtQVnVVcVg1a0VLbU9yMCIsInNraWQiOiJkaWQ6cGVlcjoyLkV6NkxTa0d5M2UyejU0dVA0VTlIeVhKWFJwYUYyeXRzblR1VmdoNlNOTm1DeUdaUVouVno2TWtqZHd2ZjloV2M2aWJabmRXOUI5N3NpOTJEU2s5aFdBaEdZQmdQOWtVRms4Wi5TZXlKMElqb2laRzBpTENKeklqb2lhSFIwY0hNNkx5OWliMkl1Wkdsa0xtWnRaM0F1WVhCd0x5SXNJbklpT2x0ZExDSmhJanBiSW1ScFpHTnZiVzB2ZGpJaVhYMCM2TFNrR3kzZTJ6NTR1UDRVOUh5WEpYUnBhRjJ5dHNuVHVWZ2g2U05ObUN5R1pRWiIsImFwdSI6IlpHbGtPbkJsWlhJNk1pNUZlalpNVTJ0SGVUTmxNbm8xTkhWUU5GVTVTSGxZU2xoU2NHRkdNbmwwYzI1VWRWWm5hRFpUVGs1dFEzbEhXbEZhTGxaNk5rMXJhbVIzZG1ZNWFGZGpObWxpV201a1Z6bENPVGR6YVRreVJGTnJPV2hYUVdoSFdVSm5VRGxyVlVack9Gb3VVMlY1U2pCSmFtOXBXa2N3YVV4RFNucEphbTlwWVVoU01HTklUVFpNZVRscFlqSkpkVnBIYkd0TWJWcDBXak5CZFZsWVFuZE1lVWx6U1c1SmFVOXNkR1JNUTBwb1NXcHdZa2x0VW5CYVIwNTJZbGN3ZG1ScVNXbFlXREFqTmt4VGEwZDVNMlV5ZWpVMGRWQTBWVGxJZVZoS1dGSndZVVl5ZVhSemJsUjFWbWRvTmxOT1RtMURlVWRhVVZvIiwidHlwIjoiYXBwbGljYXRpb24vZGlkY29tbS1lbmNyeXB0ZWQranNvbiIsImVuYyI6IkEyNTZDQkMtSFM1MTIiLCJhbGciOiJFQ0RILTFQVStBMjU2S1cifQ",
+      |	"recipients": [{
+      |		"encrypted_key": "eFHcJkoUle7ZkksvZjvhJHLagF7y5B5gDQX11tc1kus2xa3Vn_QmzyVwFzScOHTCEjWRUe7r63rHBFBw0El2ukZW2tcitxr8",
+      |		"header": {
+      |			"kid": "did:peer:2.Ez6LSghwSE437wnDE1pt3X6hVDUQzSjsHzinpX3XFvMjRAm7y.Vz6Mkhh1e5CEYYq6JBUcTZ6Cp2ranCWRrv7Yax3Le4N59R6dd.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9hbGljZS5kaWQuZm1ncC5hcHAvIiwiciI6W10sImEiOlsiZGlkY29tbS92MiJdfQ#6LSghwSE437wnDE1pt3X6hVDUQzSjsHzinpX3XFvMjRAm7y"
+      |		}
+      |	}],
+      |	"tag": "6MUE-lIZFVRId9qX-0If18EsPcfld_a3r2gQXXq4ms4",
+      |	"iv": "plEK7sqstAIkIxVKyfuuYg"
+      |}""".stripMargin.fromJson[EncryptedMessage]
+  val encryptedMessageBob: Either[String, EncryptedMessage] =
+    """{
+     |	"ciphertext": "-dyjeU0aRQ8F87yAJFbOmmuon0UtEhQpmDQhYclMiTAqi06wH2bLTjtJNIOFG9sJ12uIyaQahPzCFBUyR2X22Oyl-1-Un0LOCAoRP584JuN19NdgKIytmSm4pg4VeSJ56SKO5D3Qe3G8XQa_7vO8O9-b_6V9mQXXZDkknNbphuiD7S53ss_VJzbgQVLRxkBrbnU1PL7yC6AhkAZNkUNCS8GGYbdEKFeRsdWjoROEnuQ1zzPN28eO3T4Wmt2APQ10vHum3Bl1RTiPRGCx3C-fSi05F-521jyP0rwyLeMZdBLruDz2IrUudtimFI3CKQ8_BcmuXTlLa1vw2hKlhk1_ppAmggW-qrjyZPiC9-XIN02OxZox5Xzba-cmg05Dj2zmEXryrxqFfyJlrV5FKSvWDfqeNAA9QNE0aUsgpKK9gOmu5pJRCuYNL96lbxdSCR4BiuX1G_ma2gagdIIY-70d22UPGcrZTw7Blet574i5U_bIDpZw4Az0UxoKNDbCDPOpn-Shojo5n_5FFbaPky0H0N99-9cx-Ns-3NMQecpupPQ9QJ-A2KWBTLYrJofLCBWv_ysqJ3Cde9fQ3xi5DTB13dhbxKVCgzdHKlwnqPC0C3mjFs_eZ1jnzBiUAKLvD_aWMwqx7y8GUhSfXlX3hImqtXaKBu2Koc1esUOvQwadHUj5pSmsNKJJcQLzsOcuYz8U9peRevrft3sy7fm9Ne2L3SSsoCFJP1N8U8bRLmyhY0CDuCNlvXxy_VFoSdPms40d1BNZObhgwO9Ca8kp1r0ITl22repvpMQYcQ83m9fkTXg",
+     |	"protected": "eyJlcGsiOnsia3R5IjoiT0tQIiwiY3J2IjoiWDI1NTE5IiwieCI6ImNKRzZVeVJRbnhOM2RCa3ZQcndmZXZabFBwRzA0SzFyTzZHTjdnQkNyVFUifSwiYXB2IjoiLWNOQ3l0eFVrSHpSRE5SckV2Vm05S0VmZzhZcUtQVnVVcVg1a0VLbU9yMCIsInNraWQiOiJkaWQ6cGVlcjoyLkV6NkxTa0d5M2UyejU0dVA0VTlIeVhKWFJwYUYyeXRzblR1VmdoNlNOTm1DeUdaUVouVno2TWtqZHd2ZjloV2M2aWJabmRXOUI5N3NpOTJEU2s5aFdBaEdZQmdQOWtVRms4Wi5TZXlKMElqb2laRzBpTENKeklqb2lhSFIwY0hNNkx5OWliMkl1Wkdsa0xtWnRaM0F1WVhCd0x5SXNJbklpT2x0ZExDSmhJanBiSW1ScFpHTnZiVzB2ZGpJaVhYMCM2TFNrR3kzZTJ6NTR1UDRVOUh5WEpYUnBhRjJ5dHNuVHVWZ2g2U05ObUN5R1pRWiIsImFwdSI6IlpHbGtPbkJsWlhJNk1pNUZlalpNVTJ0SGVUTmxNbm8xTkhWUU5GVTVTSGxZU2xoU2NHRkdNbmwwYzI1VWRWWm5hRFpUVGs1dFEzbEhXbEZhTGxaNk5rMXJhbVIzZG1ZNWFGZGpObWxpV201a1Z6bENPVGR6YVRreVJGTnJPV2hYUVdoSFdVSm5VRGxyVlVack9Gb3VVMlY1U2pCSmFtOXBXa2N3YVV4RFNucEphbTlwWVVoU01HTklUVFpNZVRscFlqSkpkVnBIYkd0TWJWcDBXak5CZFZsWVFuZE1lVWx6U1c1SmFVOXNkR1JNUTBwb1NXcHdZa2x0VW5CYVIwNTJZbGN3ZG1ScVNXbFlXREFqTmt4VGEwZDVNMlV5ZWpVMGRWQTBWVGxJZVZoS1dGSndZVVl5ZVhSemJsUjFWbWRvTmxOT1RtMURlVWRhVVZvIiwidHlwIjoiYXBwbGljYXRpb24vZGlkY29tbS1lbmNyeXB0ZWQranNvbiIsImVuYyI6IkEyNTZDQkMtSFM1MTIiLCJhbGciOiJFQ0RILTFQVStBMjU2S1cifQ",
+     |	"recipients": [{
+     |		"encrypted_key": "KCjv83os8FnpVaIUgcuYV-5TIw4VYuGIoHozQ0JVlIwK2sEkxwWg10yh0UlbbcnNVfF_OBr4OkJUczj7pB0spRhvjoDHBM_s",
+     |		"header": {
+     |			"kid": "did:peer:2.Ez6LSghwSE437wnDE1pt3X6hVDUQzSjsHzinpX3XFvMjRAm7y.Vz6Mkhh1e5CEYYq6JBUcTZ6Cp2ranCWRrv7Yax3Le4N59R6dd.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9hbGljZS5kaWQuZm1ncC5hcHAvIiwiciI6W10sImEiOlsiZGlkY29tbS92MiJdfQ#6LSghwSE437wnDE1pt3X6hVDUQzSjsHzinpX3XFvMjRAm7y"
+     |		}
+     |	}],
+     |	"tag": "iR0meUd8R3X5dleMywNHq5NaGJ4g0h2tok414SJ7UGI",
+     |	"iv": "T-I0b4fIktFXVhAIFoSmQg"
+    |}""".stripMargin.fromJson[EncryptedMessage]
 
 }

--- a/mediator/src/test/scala/io/iohk/atala/mediator/protocols/DiscoverFeaturesExecuterSpec.scala
+++ b/mediator/src/test/scala/io/iohk/atala/mediator/protocols/DiscoverFeaturesExecuterSpec.scala
@@ -29,7 +29,7 @@ import io.iohk.atala.mediator.db.AgentStub.{bobAgent, bobAgentLayer}
 object DiscoverFeaturesExecuterSpec extends ZIOSpecDefault with DidAccountStubSetup with MessageSetup {
 
   override def spec = suite("DiscoverFeaturesExecuterSpec")(
-    test("DiscoverFeatures Query message") {
+    test("DiscoverFeatures Query message should return the disclose message containing the matched protocols") {
       val executer = DiscoverFeaturesExecuter
       for {
         agent <- ZIO.service[MediatorAgent]
@@ -41,10 +41,13 @@ object DiscoverFeaturesExecuterSpec extends ZIOSpecDefault with DidAccountStubSe
       } yield {
         val plainText = decryptedMessage.asInstanceOf[PlaintextMessage]
         assertTrue(plainText.`type` == FeatureDisclose.piuri) &&
-        assertTrue(featureDisclose.disclosures.nonEmpty)
+        assertTrue(featureDisclose.disclosures.nonEmpty) &&
+        assertTrue(featureDisclose.disclosures.head.id.contains("routing"))
       }
     } @@ TestAspect.before(setupAndClean),
-    test("DiscoverFeatures Query message with no match") {
+    test(
+      "DiscoverFeatures Query message doesn't match regex pattern, it should yield a disclose message with an empty body"
+    ) {
       val executer = DiscoverFeaturesExecuter
       for {
         agent <- ZIO.service[MediatorAgent]

--- a/mediator/src/test/scala/io/iohk/atala/mediator/protocols/DiscoverFeaturesExecuterSpec.scala
+++ b/mediator/src/test/scala/io/iohk/atala/mediator/protocols/DiscoverFeaturesExecuterSpec.scala
@@ -2,72 +2,47 @@ package io.iohk.atala.mediator.protocols
 
 import fmgp.did.DIDSubject
 import fmgp.did.comm.protocol.reportproblem2.{ProblemCode, ProblemReport}
-import fmgp.did.comm.protocol.discoverfeatures2._
+import fmgp.did.comm.protocol.discoverfeatures2.*
 import fmgp.did.comm.{EncryptedMessage, Operations, PlaintextMessage, SignedMessage, layerDefault}
 import fmgp.did.method.peer.DidPeerResolver
 import fmgp.util.Base64
 import io.iohk.atala.mediator.comm.MessageDispatcherJVM
 import io.iohk.atala.mediator.db.*
 import io.iohk.atala.mediator.db.MessageItemRepoSpec.encryptedMessageAlice
-import io.iohk.atala.mediator.protocols.ForwardMessageExecuter
+import io.iohk.atala.mediator.protocols.DiscoverFeaturesExecuter
 import zio.*
 import zio.ExecutionStrategy.Sequential
 import zio.http.Client
 import zio.json.*
 import zio.test.*
 import zio.test.Assertion.*
+import fmgp.did.comm.FROM
+import fmgp.did.comm.TO
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import io.iohk.atala.mediator.db.EmbeddedMongoDBInstance.*
-import io.iohk.atala.mediator.protocols.MediatorCoordinationExecuterSpec.setupAndClean
 import reactivemongo.api.bson.BSONDocument
-
+import fmgp.did.DIDSubject.*
+import fmgp.did.comm.Operations.authDecrypt
+import io.iohk.atala.mediator.app.MediatorAgent
+import io.iohk.atala.mediator.db.AgentStub.{bobAgent, bobAgentLayer}
 object DiscoverFeaturesExecuterSpec extends ZIOSpecDefault with DidAccountStubSetup with MessageSetup {
-
-  val plaintextDiscoverFeaturesQueryMessage = FeatureQuery(
-    to = Set(alice.asTO),
-    from = mediatorDid.asFROM,
-    queries = ???,
-  ).toPlaintextMessage.toFeatureQuery // Just to test the encode and parse
 
   override def spec = suite("DiscoverFeaturesExecuterSpec")(
     test("DiscoverFeatures Query message") {
       val executer = DiscoverFeaturesExecuter
       for {
-        userAccount <- ZIO.service[UserAccountRepo]
-        result <- userAccount.createOrFindDidAccount(alice)
-        msg <- ZIO.fromEither(plaintextDiscoverFeaturesQueryMessage)
+        agent <- ZIO.service[MediatorAgent]
+        msg <- ZIO.fromEither(plaintextDiscoverFeatureRequestMessage(bobAgent.id.did, agent.id.did))
         result <- executer.execute(msg)
         message <- ZIO.fromOption(result)
+        decryptedMessage <- authDecrypt(message.asInstanceOf[EncryptedMessage]).provideSomeLayer(bobAgentLayer)
+
       } yield {
-        assertTrue(message.isInstanceOf[SignedMessage])
-        val signedMessage = message.asInstanceOf[SignedMessage]
-        val jsonString = Base64.fromBase64url(signedMessage.payload.base64url).decodeToString
-        val problemReport = jsonString.fromJson[PlaintextMessage].flatMap(ProblemReport.fromPlaintextMessage)
-        assert(problemReport)(
-          isRight(
-            hasField("code", (p: ProblemReport) => p.code, equalTo(ProblemCode.ErroFail("req", "not_enroll"))) &&
-              hasField(
-                "from",
-                (p: ProblemReport) => p.from,
-                equalTo(alice)
-              )
-          )
-        )
+        val plainText = decryptedMessage.asInstanceOf[PlaintextMessage]
+        assertTrue(plainText.`type` == FeatureDisclose.piuri)
       }
     } @@ TestAspect.before(setupAndClean),
-
-    // test("Forward message for enrolled DID receives NoReply") {
-    //   val executer = ForwardMessageExecuter
-    //   for {
-    //     userAccount <- ZIO.service[UserAccountRepo]
-    //     result <- userAccount.createOrFindDidAccount(alice)
-    //     result <- userAccount.addAlias(owner = alice, newAlias = alice)
-    //     msg <- ZIO.fromEither(plaintextForwardEnrolledDidMessage)
-    //     result <- executer.execute(msg)
-    //   } yield assertTrue(result.isEmpty)
-    // } @@ TestAspect.before(setupAndClean)
-
   ).provideSomeLayer(DidPeerResolver.layerDidPeerResolver)
     .provideSomeLayer(Operations.layerDefault)
     .provideSomeLayer(Scope.default >>> Client.default >>> MessageDispatcherJVM.layer)

--- a/mediator/src/test/scala/io/iohk/atala/mediator/protocols/ForwardMessageExecutorSpec.scala
+++ b/mediator/src/test/scala/io/iohk/atala/mediator/protocols/ForwardMessageExecutorSpec.scala
@@ -18,7 +18,6 @@ import fmgp.did.DIDSubject
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import io.iohk.atala.mediator.db.EmbeddedMongoDBInstance.*
-import io.iohk.atala.mediator.protocols.MediatorCoordinationExecuterSpec.setupAndClean
 import reactivemongo.api.bson.BSONDocument
 object ForwardMessageExecutorSpec extends ZIOSpecDefault with DidAccountStubSetup with MessageSetup {
 

--- a/mediator/src/test/scala/io/iohk/atala/mediator/protocols/MediatorCoordinationExecuterSpec.scala
+++ b/mediator/src/test/scala/io/iohk/atala/mediator/protocols/MediatorCoordinationExecuterSpec.scala
@@ -47,8 +47,8 @@ object MediatorCoordinationExecuterSpec extends ZIOSpecDefault with DidAccountSt
         for {
           userAccount <- ZIO.service[UserAccountRepo]
           agent <- ZIO.service[MediatorAgent]
-          result <- userAccount.createOrFindDidAccount(DIDSubject(alice))
-          result <- userAccount.addAlias(owner = DIDSubject(alice), newAlias = DIDSubject(aliceAgent.id.did))
+          result <- userAccount.createOrFindDidAccount(alice)
+          result <- userAccount.addAlias(owner = alice, newAlias = DIDSubject(aliceAgent.id.did))
           msg <- ZIO.fromEither(plaintextMediationRequestMessage(aliceAgent.id.did, agent.id.did))
           result <- executer.execute(msg)
           message <- ZIO.fromOption(result)

--- a/mediator/src/test/scala/io/iohk/atala/mediator/protocols/MessageSetup.scala
+++ b/mediator/src/test/scala/io/iohk/atala/mediator/protocols/MessageSetup.scala
@@ -149,14 +149,30 @@ trait MessageSetup {
       |  "from" : "$didFrom",
       |  "body" : {
       |        "queries": [
-      |            { "feature-type": "goal-code", "match": ".*routing.*" }
+      |            { "feature-type": "protocol", "match": ".*routing.*" }
       |        ]
       |    },
       |  "return_route" : "all",
       |  "typ" : "application/didcomm-plain+json"
       |}""".stripMargin
       .fromJson[PlaintextMessage]
-
+  val plaintextDiscoverFeatureRequestMessageNoMatch = (didFrom: String, mediatorDid: String) =>
+    s"""{
+       |  "id" : "17f9f122-f762-4ba8-9011-39b9e7efb177",
+       |  "type" : "https://didcomm.org/discover-features/2.0/queries",
+       |  "to" : [
+       |     "$mediatorDid"
+       |  ],
+       |  "from" : "$didFrom",
+       |  "body" : {
+       |        "queries": [
+       |            { "feature-type": "protocol", "match": "routing" }
+       |        ]
+       |    },
+       |  "return_route" : "all",
+       |  "typ" : "application/didcomm-plain+json"
+       |}""".stripMargin
+      .fromJson[PlaintextMessage]
   val plaintextKeyListUpdateRequestMessage = (didFrom: String, mediatorDid: String, recipientDid: String) => s"""{
       |  "id" : "cf64e501-d524-4fd9-8314-4dc4bc652983",
       |  "type" : "https://didcomm.org/coordinate-mediation/2.0/keylist-update",

--- a/mediator/src/test/scala/io/iohk/atala/mediator/protocols/MessageSetup.scala
+++ b/mediator/src/test/scala/io/iohk/atala/mediator/protocols/MessageSetup.scala
@@ -28,8 +28,10 @@ trait MessageSetup {
     } yield {}
   }
 
-  val mediatorDid =
+  val mediatorDid = DIDSubject(
     "did:peer:2.Ez6LSkGy3e2z54uP4U9HyXJXRpaF2ytsnTuVgh6SNNmCyGZQZ.Vz6Mkjdwvf9hWc6ibZndW9B97si92DSk9hWAhGYBgP9kUFk8Z.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9ib2IuZGlkLmZtZ3AuYXBwLyIsInIiOltdLCJhIjpbImRpZGNvbW0vdjIiXX0"
+  )
+
   val plaintextForwardNotEnrolledDidMessage: Either[String, PlaintextMessage] =
     """{
      |  "id" : "c8f9712a-fdad-45d0-81d9-c610daaa9285",

--- a/mediator/src/test/scala/io/iohk/atala/mediator/protocols/MessageSetup.scala
+++ b/mediator/src/test/scala/io/iohk/atala/mediator/protocols/MessageSetup.scala
@@ -5,7 +5,9 @@ import io.iohk.atala.mediator.db.UserAccountRepo
 import reactivemongo.api.bson.BSONDocument
 import zio.ZIO
 import zio.json.*
+import fmgp.did.comm
 import reactivemongo.api.indexes.{Index, IndexType}
+import fmgp.did.DIDSubject
 trait MessageSetup {
 
   val index = Index(
@@ -136,6 +138,24 @@ trait MessageSetup {
       |  "return_route" : "all",
       |  "typ" : "application/didcomm-plain+json"
       |}""".stripMargin.fromJson[PlaintextMessage]
+
+  val plaintextDiscoverFeatureRequestMessage = (didFrom: String, mediatorDid: String) =>
+    s"""{
+      |  "id" : "17f9f122-f762-4ba8-9011-39b9e7efb177",
+      |  "type" : "https://didcomm.org/discover-features/2.0/queries",
+      |  "to" : [
+      |     "$mediatorDid"
+      |  ],
+      |  "from" : "$didFrom",
+      |  "body" : {
+      |        "queries": [
+      |            { "feature-type": "goal-code", "match": ".*routing.*" }
+      |        ]
+      |    },
+      |  "return_route" : "all",
+      |  "typ" : "application/didcomm-plain+json"
+      |}""".stripMargin
+      .fromJson[PlaintextMessage]
 
   val plaintextKeyListUpdateRequestMessage = (didFrom: String, mediatorDid: String, recipientDid: String) => s"""{
       |  "id" : "cf64e501-d524-4fd9-8314-4dc4bc652983",


### PR DESCRIPTION
Implementation for https://github.com/input-output-hk/atala-prism-mediator/issues/149 (Jira [ATL-5507](https://input-output.atlassian.net/browse/ATL-5507))

At the moment the list of supported protocols is hard coded.
But would be nice if this list was dynamically created when the mediator starts. Based on the protocol executors enabled.

[ATL-5507]: https://input-output.atlassian.net/browse/ATL-5507?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ