### PR TITLE
chore(infra): add additionalEnvVariables to the deployment.yaml Helm template

### DIFF
--- a/infrastructure/charts/mediator/templates/deployment.yaml
+++ b/infrastructure/charts/mediator/templates/deployment.yaml
@@ -41,3 +41,7 @@ spec:
           value: "mediator"
         - name: SERVICE_ENDPOINTS
           value: "https://{{ index .Values.ingress.applicationUrls 0 }};wss://{{ index .Values.ingress.applicationUrls 0 }}/ws"
+        { { - range $key, $value := .Values.server.additionalEnvVariables } }
+        - name: { { $key } }
+          value: { { $value | quote } }
+        { { - end } }

--- a/infrastructure/charts/mediator/templates/deployment.yaml
+++ b/infrastructure/charts/mediator/templates/deployment.yaml
@@ -41,7 +41,7 @@ spec:
           value: "mediator"
         - name: SERVICE_ENDPOINTS
           value: "https://{{ index .Values.ingress.applicationUrls 0 }};wss://{{ index .Values.ingress.applicationUrls 0 }}/ws"
-        { { - range $key, $value := .Values.server.additionalEnvVariables } }
-        - name: { { $key } }
-          value: { { $value | quote } }
-        { { - end } }
+        {{- range $key, $value := .Values.server.additionalEnvVariables }}
+        - name: {{ $key }}
+          value: {{ $value | quote }}
+        {{- end }}

--- a/infrastructure/charts/mediator/values.yaml
+++ b/infrastructure/charts/mediator/values.yaml
@@ -24,6 +24,8 @@ server:
     requests:
       cpu: 250m
       memory: 512Mi
+  # Additional environment variables to be added to the server container
+  additionalEnvVariables: {}
 
 database:
   mongodb:


### PR DESCRIPTION
Added `additionalEnvVariables` to the `deployment.yaml` template, consistent with what exists in the OEA repo. This will enable Manage (and others using this chart) to customise environment variables passed to the mediator application container.