### PR TITLE
docs: add a PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,14 @@
+### Description: 
+Summarize the changes you're submitting in a few sentences, including Jira ticket ATL-xxxx if applicable.
+Link to any discussion, related issues and bug reports to give the context to help the reviewer understand the PR.
+
+### Alternatives Considered (optional): 
+Link to existing ADR (Architecture Decision Record), if any. If relevant, describe other approaches explored and the selected approach. Documenting why the methods were not selected will create a knowledge base for future reference, helping prevent others from revisiting less optimal ideas.
+
+### Checklist: 
+- [] My PR follows the contribution guidelines of this project
+- [] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
+- [] I have commented my code, particularly in hard-to-understand areas
+- [] I have made corresponding changes to the documentation
+- [] I have added tests that prove my fix is effective or that my feature works
+- [] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)


### PR DESCRIPTION
This PR is to add this PR template which is used as below:

### Description: 
Update the PR template to the one that was agreed by the IO tribe and that will be applicable to all related repositories, this one included. 

### Checklist: 
- [x] My PR follows the contribution guidelines of this project
- [x] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)