### PR TITLE
feat(mediator) : Add TTL for message collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,21 @@ To set up the mediator storage (MongoDB):
 - `MONGODB_PASSWORD` - is the password used by the Mediator service to connect to the database.
 - `MONGODB_DB_NAME` - is the name of the database used by the Mediator.
 
+#### Mediator storage 
+- The `messages` collection contains two types of messages: `Mediator` and `User`.
+1. **Mediator Messages**:
+    - These messages received by mediator for any interactions with the mediator.
+    - Examples include messages for setting up mediation, requesting mediation, or picking up messages from the mediator.
+    - These messages stored in collection can be used for debugging purpose mediator functionality and interactions with the mediator. Hence they can be deleted after a period of time.
+    - This message type `Mediator` can be setup to have a configurable Time-To-Live (TTL) value, after which they can expire.
+    - This is how the TTL can be configured for the collection messages [initdb.js](initdb.js)
+2. **User Messages**:
+    - These are the actual messages e.g like the Forward message from the mediator, contain a `User` message inside.  This inside message is stored as type `User` to be delivered to user.
+    - They do not have a TTL, and will persist in the system until the user retrieves them using a pickup protocol and deletes them.
+    - The mediator is responsible for storing and making these user messages available for delivery to the intended recipients.
+ 
+  ℹ️ For existing users, please utilize the migration script [migration_mediator_collection.js](migration_mediator_collection.js) to migrate the collection.
+
 ## Run
 
 The DIDComm Mediator comprises two elements: a backend service and a database.

--- a/infrastructure/charts/mediator/templates/mongodb.yaml
+++ b/infrastructure/charts/mediator/templates/mongodb.yaml
@@ -62,6 +62,16 @@ data:
     // Only enforce uniqueness on non-empty arrays
     db.getCollection(collectionDidAccount).createIndex({ 'alias': 1 }, { unique: true , partialFilterExpression: { "alias.0": { $exists: true } }});
     db.getCollection(collectionDidAccount).createIndex({ "messagesRef.hash": 1, "messagesRef.recipient": 1 });
+    // 7 day * 24 hours * 60 minutes * 60 seconds
+    const expireAfterSeconds = 7 * 24 * 60 * 60; 
+    db.getCollection(collectionMessages).createIndex(
+        { ts: 1 },
+        {
+            name: "message-ttl-index",
+            partialFilterExpression: { "message_type" : "Mediator" },
+            expireAfterSeconds: expireAfterSeconds
+        }
+    );
 ---
 apiVersion: v1
 kind: Service

--- a/initdb.js
+++ b/initdb.js
@@ -24,3 +24,14 @@ db.getCollection(collectionDidAccount).createIndex({ 'did': 1 }, { unique: true 
 // Only enforce uniqueness on non-empty arrays
 db.getCollection(collectionDidAccount).createIndex({ 'alias': 1 }, { unique: true, partialFilterExpression: { "alias.0": { $exists: true } } });
 db.getCollection(collectionDidAccount).createIndex({ "messagesRef.hash": 1, "messagesRef.recipient": 1 });
+
+// There are 2 message types  `Mediator`  and `User` Please follow the Readme for more details in the section Mediator storage
+const expireAfterSeconds = 7 * 24 * 60 * 60; // 7 day * 24 hours * 60 minutes * 60 seconds
+db.getCollection(collectionMessages).createIndex(
+    { ts: 1 },
+    {
+        name: "message-ttl-index",
+        partialFilterExpression: { "message_type" : "Mediator" },
+        expireAfterSeconds: expireAfterSeconds
+    }
+)

--- a/mediator/src/main/scala/org/hyperledger/identus/mediator/AgentExecutorMediator.scala
+++ b/mediator/src/main/scala/org/hyperledger/identus/mediator/AgentExecutorMediator.scala
@@ -287,7 +287,7 @@ object AgentExecutorMediator {
             em.`protected`.obj match
               case AnonProtectedHeader(epk, apv, typ, enc, alg)            => ops.anonDecrypt(em)
               case AuthProtectedHeader(epk, apv, skid, apu, typ, enc, alg) => ops.authDecrypt(em)
-          }.flatMap(decrypt _)
+          }.flatMap(decrypt)
         case sm: SignedMessage =>
           ops.verify(sm).flatMap {
             case false => ZIO.fail(ValidationFailed)

--- a/mediator/src/main/scala/org/hyperledger/identus/mediator/protocols/ForwardMessageExecuter.scala
+++ b/mediator/src/main/scala/org/hyperledger/identus/mediator/protocols/ForwardMessageExecuter.scala
@@ -11,6 +11,7 @@ import org.hyperledger.identus.mediator.db.*
 import zio.*
 import zio.json.*
 import fmgp.did.comm.protocol.pickup3.MessageDelivery
+import org.hyperledger.identus.mediator.db.MessageType.User
 
 object ForwardMessageExecuter
     extends ProtocolExecuter[
@@ -36,7 +37,7 @@ object ForwardMessageExecuter
           msg <-
             if (numbreOfUpdated > 0) { // Or maybe we can add all the time
               for {
-                _ <- repoMessageItem.insert(m.msg)
+                _ <- repoMessageItem.insert(m.msg, User)
                 _ <- ZIO.logInfo("Add next msg (of the ForwardMessage) to the Message Repo")
 
                 // For Live Mode

--- a/migration_mediator_collection.js
+++ b/migration_mediator_collection.js
@@ -1,0 +1,31 @@
+// migration script
+// Please utilize the following script to update your existing collection for Mediator release v0.14.5 and beyond.
+const collectionName = 'messages';
+const collectionNameUserAccount = 'user.account';
+let userHashes = [];
+
+db.getCollection(collectionNameUserAccount).find({}).forEach(function(user) {
+    user.messagesRef.forEach(function(messageRef) {
+        userHashes.push(messageRef.hash);
+    });
+});
+
+db.getCollection('messages').find({}).forEach(function(message) {
+    let newTimestamp = new Date(message.ts);
+    if(userHashes.includes(message._id)) {
+        db.getCollection('messages').updateOne({ _id: message._id }, { $set: { message_type: 'User', ts: newTimestamp } });
+    } else {
+        db.getCollection('messages').updateOne({ _id: message._id }, { $set: { message_type: 'Mediator', ts: newTimestamp } });
+    }
+});
+
+// There are 2 message types  `Mediator`  and `User` Please follow the Readme for more details in the section Mediator storage
+const expireAfterSeconds = 7 * 24 * 60 * 60; // 7 day * 24 hours * 60 minutes * 60 seconds
+db.getCollection(collectionMessages).createIndex(
+    { ts: 1 },
+    {
+        name: "message-ttl-index",
+        partialFilterExpression: { "message_type" : "Mediator" },
+        expireAfterSeconds: expireAfterSeconds
+    }
+)


### PR DESCRIPTION
### Description: 
Storing every message received by the mediator in the messages collection can lead to significant growth in the collection size. However, not all received messages need to be kept once the relevant action is completed, except for those intended for delivery to the recipient. Therefore, implementing a TTL index for the messages collection, with a filter to expire mediator messages, would optimize storage usage and efficiency.

### Alternatives Considered (optional): 


### Checklist: 
- [x] My PR follows the contribution guidelines of this project
- [x] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)
