### PR TITLE
ci: add conventionalcommits preset to the semantic-release

### DIFF
--- a/release.config.mjs
+++ b/release.config.mjs
@@ -5,7 +5,9 @@ export default {
         { name: 'beta/*', prerelease: 'rc' }
     ],
     plugins: [
-        '@semantic-release/commit-analyzer',
+        ['@semantic-release/commit-analyzer', {
+            "preset": "conventionalcommits"
+        }],
         '@semantic-release/release-notes-generator',
         ["@semantic-release/changelog", {
             "changelogFile": "CHANGELOG.md"


### PR DESCRIPTION
### Description: 
`conventionalcommits` preset is configured for the semantic-release commit-analyzer plugin to react to the `!` mark in the commit message and increment the major version of the component

### Checklist: 
- [ ] My PR follows the contribution guidelines of this project
- [ ] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)
