### PR TITLE
ci: add embedded mongo to the exclusion list of the scala-steward config

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -12,6 +12,11 @@ dependencyOverrides = [
   }
 ]
 
+updates.ignore = [
+  # this dependency should be updated manually because scala-steward doesn't have permissions to update the ci.yml file
+  { groupId = "de.flapdoodle.embed", artifactId = "de.flapdoodle.embed.mongo" }
+]
+
 # If set, Scala Steward will use this message template for the commit messages and PR titles.
 # Supported variables: ${artifactName}, ${currentVersion}, ${nextVersion} and ${default}
 # Default: "${default}" which is equivalent to "Update ${artifactName} to ${nextVersion}"

--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -11,3 +11,8 @@ dependencyOverrides = [
     # pullRequests = { frequency = "@monthly" },
   }
 ]
+
+# If set, Scala Steward will use this message template for the commit messages and PR titles.
+# Supported variables: ${artifactName}, ${currentVersion}, ${nextVersion} and ${default}
+# Default: "${default}" which is equivalent to "Update ${artifactName} to ${nextVersion}"
+commits.message = "${default}\n\nSigned-off-by: Hyperledger Bot <hyperledger-bot@hyperledger.org>"


### PR DESCRIPTION
### Checklist: 
- [x] My PR follows the contribution guidelines of this project
- [x] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)
