### PR TITLE
build: fix the invalid tag when calling docker:publishLocal

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -233,6 +233,7 @@ lazy val mediator = project
     Docker / dockerUsername := Some("hyperledger"),
     Docker / dockerRepository := Some("ghcr.io"),
     Docker / packageName := "identus-mediator",
+    Docker / version := (Compile / version).value.replace("+", "_"),
     dockerExposedPorts := Seq(8080),
     dockerBaseImage := "openjdk:11",
     dockerUpdateLatest := true,


### PR DESCRIPTION
There was an regression when calling docker:publishLocal one stable versions or dirty commit

In docker "The tag must be valid ASCII and can contain lowercase and uppercase letters, digits, underscores, periods, and hyphens"
I see a `+` in the default generated version (`1.0.0+6-1bdc62a6+20241225-0337-SNAPSHOT`)
The default generated version is preferable instead of the one that we introduced before (with over complicated logic). It was removed because it was causing caching problems another places.
The solution was to replace all `+` for `_` in SBT's docker:publishLocal command.


This problem was report on Discord by `kid0410` https://discord.com/channels/1146426895114702858/1156506829287850025/1321321978862506029