### PR TITLE
ci: update actions/cache version in ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Cache sbt
         uses: coursier/cache-action@v6.3
       - name: Cache embedmongo
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.embedmongo
           key: ${{ runner.os }}-embedmongo-4.14.0


### PR DESCRIPTION
Use actions/cache@v4 in ci.yml

Fix for the job that is failing in https://github.com/hyperledger-identus/mediator/pull/437