### PR TITLE
ci: fix how JOB INFO logs CONTEXT

### DIFF
--- a/.github/workflows/release-docker-hub.yml
+++ b/.github/workflows/release-docker-hub.yml
@@ -90,17 +90,22 @@ jobs:
             type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
 
       - name: JOB INFO
+        env:
+          RUNNER_CONTEXT: ${{ toJson(runner) }}
+          GITHUB_CONTEXT: ${{ toJson(github) }}
+          JOB_CONTEXT: ${{ toJson(job) }}
         run: |
           echo "##################"
           echo "#### JOB INFO ####"
           echo "##################"
-          echo "### github.event_name=${{ github.event_name }}     (Is this type 'schedule'""? ${{ github.event_name == 'schedule' }})"
+          echo "### github.event_name=${{ github.event_name }}"
           echo "### TAGS: ${{ steps.meta.outputs.tags == '' }}"
           echo "### DOCKERHUB_USERNAME: ${{ vars.DOCKERHUB_USERNAME }}"
           echo "### DOCKERHUB_ORG: ${{ vars.DOCKERHUB_ORG }}"
           echo "${{ steps.meta.outputs.tags }}"
-          echo "### runner: ${{ toJSON(runner) }}"
-          echo "### github: ${{ toJSON(github) }}"
+          echo "### RUNNER_CONTEXT: $RUNNER_CONTEXT"
+          echo "### GITHUB_CONTEXT: $GITHUB_CONTEXT"
+          echo "### JOB_CONTEXT: $JOB_CONTEXT"
 
       - name: Download docker-directory-artifact
         uses: actions/download-artifact@v4


### PR DESCRIPTION
Github update the new new recommendation how to log the CONTEXT See https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/accessing-contextual-information-about-workflow-runs#example-printing-context-information-to-the-log

