### PR TITLE
fix: adding mediator advanced connection strings for production

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,7 @@ services:
       - KEY_AUTHENTICATION_D=INXCnxFEl0atLIIQYruHzGd5sUivMRyQOzu87qVerug
       - KEY_AUTHENTICATION_X=MBjnXZxkMcoQVVL21hahWAw43RuAG-i64ipbeKKqwoA
       - SERVICE_ENDPOINTS=${SERVICE_ENDPOINTS:-http://localhost:8080;ws://localhost:8080/ws}
+      # OR MONGODB_CONNECTION_STRING with full connection string
       - MONGODB_USER=admin
       - MONGODB_PASSWORD=admin
       - MONGODB_PROTOCOL=mongodb

--- a/mediator/src/main/resources/application.conf
+++ b/mediator/src/main/resources/application.conf
@@ -18,6 +18,9 @@ mediator = {
   server.http.port = 8080
   server.http.port = ${?PORT}
   database = {
+    # Connection string takes precedence over individual components if provided
+    connectionString = ${?MONGODB_CONNECTION_STRING}
+    # Individual components (fallback if no connection string provided)
     protocol = mongodb
     protocol = ${?MONGODB_PROTOCOL}
     port = 27017


### PR DESCRIPTION
Most production environments will use mongodb connection strings. 
Currently, the mediator allows you to connect using db, name, password which is good for local deployments.

Advanced connection strings and providers like mongoDB Atlas are right now not compatible.

What is a connection string in mongodb?
mongodb+srv://[username]:[password]@[hostname]/[dbName]?retryWrites=true&w=majority&appName=mediator

This PR makes it compatible with either old connection settings or full connection string, new env var is MONGODB_CONNECTION_STRING. 

Using MONGODB_CONNECTION_STRING will have preference over the other values if present.

Don't know much about scala but build this docker image locally with sbt and tested using my mongodb prod instance. 

it all works