### PR TITLE
ci: fix sbt-dependency-submission

### DIFF
--- a/.github/workflows/sbt-dependency-submission.yml
+++ b/.github/workflows/sbt-dependency-submission.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Java and Scala
         uses: olafurpg/setup-scala@v14
         with:
-          java-version: adopt@1.17
+          java-version: openjdk@1.17.0
       - name: Setup Node
         uses: actions/setup-node@v3
         with:


### PR DESCRIPTION
Use the java version from openjdk@1.17.0
Fix for `Error: Couldn't find Java adopt@1.17. To fix this problem, run 'jabba ls-remote' to see the list of valid Java versions.`
https://github.com/hyperledger-identus/mediator/actions/runs/17809341821/job/50628980917