### PR TITLE
fix: scala-steward persmission

### DIFF
--- a/.github/workflows/scala-steward.yml
+++ b/.github/workflows/scala-steward.yml
@@ -14,6 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Scala Steward
     permissions:
+      contents: write
       issues: write
       pull-requests: write
     steps:


### PR DESCRIPTION


## What was changed and what it is solving
the permission required for content write
## How it was tested

## Release Notes / Changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
This is what will be user facing in the release note.
If there is no need, write "None".
It must be placed inside the below triple backticks section:
-->
```markdown changelog

```

