### PR TITLE
ci: fix for #589 - Steward's PRs MUST automatically start the CI

### DIFF
--- a/.github/workflows/scala-steward.yml
+++ b/.github/workflows/scala-steward.yml
@@ -6,17 +6,10 @@ on:
 
 name: Scala Steward
 
-permissions:
-  contents: read
-
 jobs:
   scala-steward:
     runs-on: ubuntu-latest
     name: Scala Steward
-    permissions:
-      contents: write
-      issues: write
-      pull-requests: write
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@df199fb7be9f65074067a9eb93f12bb4c5547cf2 # v2.13.3
@@ -51,7 +44,7 @@ jobs:
           echo "email:       ${{ steps.import_gpg.outputs.email }}"
 
       - name: Launch Scala Steward
-        uses: scala-steward-org/scala-steward-action@f60ccd18bc9d8083e6809d9dc3db4a69a71d856c # v2.78.0
+        uses: scala-steward-org/scala-steward-action@df2a4cec1721d0b48be3e1d1f0acdf7543ea0fb4 # v2.84.0
         with:
           github-token: ${{ secrets.HYP_BOT_STEWARD_GITHUB_TOKEN }}
           sign-commits: true

--- a/.github/workflows/scala-steward.yml
+++ b/.github/workflows/scala-steward.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Launch Scala Steward
         uses: scala-steward-org/scala-steward-action@df2a4cec1721d0b48be3e1d1f0acdf7543ea0fb4 # v2.84.0
         with:
-          github-token: ${{ secrets.HYP_BOT_STEWARD_GITHUB_TOKEN }}
+          github-token: ${{ secrets.FABIO_BOT_STEWARD_GITHUB_TOKEN }}
           sign-commits: true
           signing-key: ${{ steps.import_gpg.outputs.keyid }}
           author-email: ${{ steps.import_gpg.outputs.email }}

--- a/.github/workflows/scala-steward.yml
+++ b/.github/workflows/scala-steward.yml
@@ -52,10 +52,8 @@ jobs:
 
       - name: Launch Scala Steward
         uses: scala-steward-org/scala-steward-action@f60ccd18bc9d8083e6809d9dc3db4a69a71d856c # v2.78.0
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.HYP_BOT_STEWARD_GITHUB_TOKEN }}
           sign-commits: true
           signing-key: ${{ steps.import_gpg.outputs.keyid }}
           author-email: ${{ steps.import_gpg.outputs.email }}

--- a/.github/workflows/scala-steward.yml
+++ b/.github/workflows/scala-steward.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Launch Scala Steward
         uses: scala-steward-org/scala-steward-action@df2a4cec1721d0b48be3e1d1f0acdf7543ea0fb4 # v2.84.0
         with:
-          github-token: ${{ secrets.FABIO_BOT_STEWARD_GITHUB_TOKEN }}
+          github-token: ${{ secrets.HYP_BOT_STEWARD_GITHUB_TOKEN }}
           sign-commits: true
           signing-key: ${{ steps.import_gpg.outputs.keyid }}
           author-email: ${{ steps.import_gpg.outputs.email }}


### PR DESCRIPTION
## What was changed and what it is solving

Replaced GITHUB_TOKEN with HYP_BOT_STEWARD_GITHUB_TOKEN for Scala Steward action.

## How it was tested

I'll test it manually.