### PR TITLE
ci(mediator): align release workflow with Java 17

### DIFF
--- a/.github/workflows/release-docker-hub.yml
+++ b/.github/workflows/release-docker-hub.yml
@@ -54,7 +54,8 @@ jobs:
       - name: Setup Java and Scala
         uses: olafurpg/setup-scala@32ffa16635ff8f19cc21ea253a987f0fdf29844c # v14
         with:
-          java-version: zulu@1.11.0
+          # Keep this aligned with CI. Current dependencies require Java 17 bytecode support.
+          java-version: openjdk@1.17
 
       - name: Cache sbt
         uses: coursier/cache-action@95e5b1029b6b86e7bac033ee44a0697d8a527d2d # v8.1.1


### PR DESCRIPTION
## Summary
- align `release-docker-hub.yml` with the repository CI Java version
- switch the release workflow from Java 11 to Java 17
- document in the workflow why it must stay aligned with CI

## Why
Recent `Release to Docker Hub` runs on `main` fail in `build-binaries` before any Docker image is published.

The failing step uses Java 11, while the current dependency set on `main` includes Java 17 bytecode. The failure in the workflow log is:

```text
java.lang.UnsupportedClassVersionError: zio/json/IsUnionOf$ has been compiled by a more recent version of the Java Runtime (class file version 61.0), this version of the Java Runtime only recognizes class file versions up to 55.0
```

Regular CI is already green on Java 17, so the release workflow had drifted from the validated build environment.

## Validation
- confirmed the latest failed release workflow on `main` fails in `build-binaries` with `UnsupportedClassVersionError`
- confirmed normal CI on the same commit is green and already runs on Java 17
- parsed the updated workflow YAML locally

## Expected impact
This should unblock the `build-binaries` stage in `Release to Docker Hub`, allowing the existing Docker artifact and push steps to run again.
