### PR TITLE
fix(ci): stabilize mediator release dispatch

### DIFF
--- a/.github/workflows/release-docker-hub.yml
+++ b/.github/workflows/release-docker-hub.yml
@@ -177,6 +177,7 @@ jobs:
       # This dispatch is to trigger the automatic E2E execution.
       # https://github.com/hyperledger-identus/integration
       - name: Trigger component integration
+        continue-on-error: true
         uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4.0.1
         with:
           token: ${{ secrets.IDENTUS_CI }}
@@ -187,7 +188,7 @@ jobs:
               "component": "mediator",
               "version": "${{
                 github.ref_type == 'tag'
-                && steps.semver_tag.outputs.tags
-                || steps.sha_tag.outputs.tags
+                && steps.semver_tag.outputs.version
+                || steps.sha_tag.outputs.version
               }}"
             }


### PR DESCRIPTION
## Summary
- use a single version string for the integration repository dispatch payload
- avoid invalid JSON when semver metadata produces multiple tags such as `1.2.1` and `latest`
- keep the downstream integration dispatch non-blocking so a published image does not mark the release workflow failed

## Validation
- verified release run `27262758865` already published `1.2.1`, `latest`, and `sha-b85da0bfc24a4aaba57223c98e7b15fbaf866948`
- verified the failing step was `Bad control character in string literal in JSON at position 94`
- checked workflow diff with `git diff --check`
